### PR TITLE
make settings page thread safe for game bar widget scenarios

### DIFF
--- a/src/Notepads/Controls/FindAndReplace/FindAndReplaceControl.xaml.cs
+++ b/src/Notepads/Controls/FindAndReplace/FindAndReplaceControl.xaml.cs
@@ -3,6 +3,7 @@
     using System;
     using Notepads.Services;
     using Windows.System;
+    using Windows.UI.Core;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Controls;
     using Windows.UI.Xaml.Input;
@@ -39,9 +40,12 @@
             ThemeSettingsService.OnAccentColorChanged -= ThemeSettingsService_OnAccentColorChanged;
         }
 
-        private void ThemeSettingsService_OnAccentColorChanged(object sender, Windows.UI.Color e)
+        private async void ThemeSettingsService_OnAccentColorChanged(object sender, Windows.UI.Color e)
         {
-            SetSelectionHighlightColor();
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                SetSelectionHighlightColor();
+            });
         }
 
         public double GetHeight(bool showReplaceBar)

--- a/src/Notepads/Controls/GoTo/GoToControl.xaml.cs
+++ b/src/Notepads/Controls/GoTo/GoToControl.xaml.cs
@@ -4,6 +4,7 @@
     using Notepads.Services;
     using Windows.ApplicationModel.Resources;
     using Windows.System;
+    using Windows.UI.Core;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Controls;
     using Windows.UI.Xaml.Input;
@@ -53,9 +54,12 @@
             ThemeSettingsService.OnAccentColorChanged -= ThemeSettingsService_OnAccentColorChanged;
         }
 
-        private void ThemeSettingsService_OnAccentColorChanged(object sender, Windows.UI.Color e)
+        private async void ThemeSettingsService_OnAccentColorChanged(object sender, Windows.UI.Color e)
         {
-            SetSelectionHighlightColor();
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                SetSelectionHighlightColor();
+            });
         }
 
         public double GetHeight()

--- a/src/Notepads/Controls/Settings/AdvancedSettings.xaml
+++ b/src/Notepads/Controls/Settings/AdvancedSettings.xaml
@@ -49,11 +49,12 @@
                     <TextBlock x:Uid="/Settings/AdvancedPage_SessionSnapshotSettings_Description" Style="{ThemeResource CaptionTextBlockStyle}" FontStyle="Italic" Margin="0,8,0,0"/>
                 </StackPanel>
                 <TextBlock
+                    x:Name="LaunchPreferenceSettingsTitle"
                     x:Uid="/Settings/AdvancedPage_LaunchPreferenceSettings_Title"
                     Style="{StaticResource TitleTextBlockStyle}"
                     Margin="0,35,0,0"
                     FontWeight="Normal"/>
-                <StackPanel Margin="0,10,0,0">
+                <StackPanel x:Name="LaunchPreferenceSettingsControls" Margin="0,10,0,0">
                     <ToggleSwitch x:Uid="/Settings/AdvancedPage_LaunchPreferenceSettings_AlwaysOpenNewWindowToggleSwitch"
                                   Style="{StaticResource CustomToggleSwitchStyle}" 
                                   x:Name="AlwaysOpenNewWindowToggleSwitch" 

--- a/src/Notepads/Controls/Settings/AdvancedSettings.xaml.cs
+++ b/src/Notepads/Controls/Settings/AdvancedSettings.xaml.cs
@@ -27,6 +27,13 @@
 
             Loaded += AdvancedSettings_Loaded;
             Unloaded += AdvancedSettings_Unloaded;
+
+            if (App.IsGameBarWidget)
+            {
+                // these settings don't make sense for Game Bar, there can be only one
+                LaunchPreferenceSettingsTitle.Visibility = Visibility.Collapsed;
+                LaunchPreferenceSettingsControls.Visibility = Visibility.Collapsed;
+            }
         }
 
         private void AdvancedSettings_Loaded(object sender, RoutedEventArgs e)

--- a/src/Notepads/Controls/Settings/PersonalizationSettings.xaml
+++ b/src/Notepads/Controls/Settings/PersonalizationSettings.xaml
@@ -35,12 +35,12 @@
                     <RadioButton x:Uid="/Settings/PersonalizationPage_ThemeModeSettings_DarkModeRadioButton" Style="{StaticResource CustomRadioButtonStyle}" x:Name="ThemeModeDarkButton" Tag="Dark" />
                     <RadioButton x:Uid="/Settings/PersonalizationPage_ThemeModeSettings_WindowsModeRadioButton" Style="{StaticResource CustomRadioButtonStyle}" x:Name="ThemeModeDefaultButton" Tag="Default" />
                 </StackPanel>
-                <TextBlock
+                <TextBlock x:Name="BackgroundTintTitle"
                     x:Uid="/Settings/PersonalizationPage_BackgroundTintOpacitySettings_Title"
                     Style="{StaticResource TitleTextBlockStyle}"
                     Margin="0,35,0,0"
                     FontWeight="Normal"/>
-                <StackPanel Margin="0,10,0,0">
+                <StackPanel x:Name="BackgroundTintTitleControls" Margin="0,10,0,0">
                     <StackPanel Orientation="Horizontal">
                         <Slider Style="{StaticResource CustomSliderStyle}" 
                                 x:Name="BackgroundTintOpacitySlider"

--- a/src/Notepads/Controls/Settings/PersonalizationSettings.xaml.cs
+++ b/src/Notepads/Controls/Settings/PersonalizationSettings.xaml.cs
@@ -36,6 +36,13 @@
 
             Loaded += PersonalizationSettings_Loaded;
             Unloaded += PersonalizationSettings_Unloaded;
+
+            if (App.IsGameBarWidget)
+            {
+                // Game Bar widgets do not support transparency, disable this setting
+                BackgroundTintTitle.Visibility = Visibility.Collapsed;
+                BackgroundTintTitleControls.Visibility = Visibility.Collapsed;
+            }
         }
 
         private void ThemeSettingsService_OnAccentColorChanged(object sender, Windows.UI.Color color)

--- a/src/Notepads/Controls/Settings/SettingsPage.xaml.cs
+++ b/src/Notepads/Controls/Settings/SettingsPage.xaml.cs
@@ -1,9 +1,13 @@
 ﻿namespace Notepads.Controls.Settings
 {
     using Microsoft.Gaming.XboxGameBar;
+    using Notepads.Services;
+    using System;
     using System.Linq;
+    using Windows.UI.ViewManagement;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Controls;
+    using Windows.UI.Xaml.Media;
     using Windows.UI.Xaml.Navigation;
 
     public sealed partial class SettingsPage : Page
@@ -14,6 +18,30 @@
         {
             InitializeComponent();
             Loaded += SettingsPage_Loaded;
+
+            if (App.IsGameBarWidget)
+            {
+                ThemeSettingsService.OnRequestThemeUpdate += ThemeSettingsService_OnRequestThemeUpdate;
+                ThemeSettingsService.OnRequestAccentColorUpdate += ThemeSettingsService_OnRequestAccentColorUpdate;
+
+                ThemeSettingsService.SetRequestedTheme(null, Window.Current.Content, null);
+            }
+        }
+
+        private async void ThemeSettingsService_OnRequestAccentColorUpdate(object sender, EventArgs e)
+        {
+            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                ThemeSettingsService.SetRequestedAccentColor();
+            });
+        }
+
+        private async void ThemeSettingsService_OnRequestThemeUpdate(object sender, EventArgs e)
+        {
+            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                ThemeSettingsService.SetRequestedTheme(null, Window.Current.Content, null);
+            });
         }
 
         private void SettingsPage_Loaded(object sender, RoutedEventArgs e)

--- a/src/Notepads/Controls/TextEditor/ITextEditor.cs
+++ b/src/Notepads/Controls/TextEditor/ITextEditor.cs
@@ -6,6 +6,7 @@
     using Notepads.Models;
     using Notepads.Utilities;
     using Windows.Storage;
+    using Windows.UI;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Controls;
     using Windows.UI.Xaml.Input;
@@ -27,6 +28,7 @@
         event EventHandler ChangeReverted;
         event EventHandler FileSaved;
         event EventHandler FileReloaded;
+        event EventHandler<Color> AccentColorChanged;
 
         Guid Id { get; set; }
 

--- a/src/Notepads/Controls/TextEditor/TextEditor.xaml.cs
+++ b/src/Notepads/Controls/TextEditor/TextEditor.xaml.cs
@@ -977,42 +977,60 @@
             }
         }
 
-        private void LineHighlighter_OnViewStateChanged(object sender, bool enabled)
+        private async void LineHighlighter_OnViewStateChanged(object sender, bool enabled)
         {
-            if (enabled)
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                LineHighlighter.Visibility = Visibility.Visible;
-                DrawLineHighlighter();
-            }
-            else
+                if (enabled)
+                {
+                    LineHighlighter.Visibility = Visibility.Visible;
+                    DrawLineHighlighter();
+                }
+                else
+                {
+                    LineHighlighter.Visibility = Visibility.Collapsed;
+                }
+            });
+        }
+
+        private async void LineHighlighter_OnSelectionChanged(object sender, RoutedEventArgs e)
+        {
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                LineHighlighter.Visibility = Visibility.Collapsed;
-            }
+                if (EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            });
         }
 
-        private void LineHighlighter_OnSelectionChanged(object sender, RoutedEventArgs e)
+        private async void LineHighlighter_OnTextWrappingChanged(object sender, TextWrapping e)
         {
-            if (EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                if (EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            });
         }
 
-        private void LineHighlighter_OnTextWrappingChanged(object sender, TextWrapping e)
+        private async void LineHighlighter_OnFontSizeChanged(object sender, double e)
         {
-            if (EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                if (EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            });
         }
 
-        private void LineHighlighter_OnFontSizeChanged(object sender, double e)
+        private async void LineHighlighter_WindowSizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                if (EditorSettingsService.EditorDefaultTextWrapping == TextWrapping.Wrap && EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            });
         }
 
-        private void LineHighlighter_WindowSizeChanged(object sender, SizeChangedEventArgs e)
+        private async void LineHighlighter_OnScrolled(object sender, ScrollViewerViewChangedEventArgs e)
         {
-            if (EditorSettingsService.EditorDefaultTextWrapping == TextWrapping.Wrap && EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
-        }
-
-        private void LineHighlighter_OnScrolled(object sender, ScrollViewerViewChangedEventArgs e)
-        {
-            if (EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                if (EditorSettingsService.IsLineHighlighterEnabled) DrawLineHighlighter();
+            });
         }
     }
 }

--- a/src/Notepads/Controls/TextEditor/TextEditor.xaml.cs
+++ b/src/Notepads/Controls/TextEditor/TextEditor.xaml.cs
@@ -19,6 +19,7 @@
     using Windows.ApplicationModel.Resources;
     using Windows.Storage;
     using Windows.System;
+    using Windows.UI;
     using Windows.UI.Core;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Controls;
@@ -70,6 +71,8 @@
         public event EventHandler FileSaved;
 
         public event EventHandler FileReloaded;
+
+        public event EventHandler<Color> AccentColorChanged;
 
         private const char RichEditBoxDefaultLineEnding = '\r';
 
@@ -187,6 +190,7 @@
             _keyboardCommandHandler = GetKeyboardCommandHandler();
 
             ThemeSettingsService.OnThemeChanged += ThemeSettingsService_OnThemeChanged;
+            ThemeSettingsService.OnAccentColorChanged += ThemeSettingsService_OnAccentColorChanged;
 
             base.Loaded += TextEditor_Loaded;
             base.Unloaded += TextEditor_Unloaded;
@@ -223,6 +227,7 @@
             }
 
             ThemeSettingsService.OnThemeChanged -= ThemeSettingsService_OnThemeChanged;
+            ThemeSettingsService.OnAccentColorChanged -= ThemeSettingsService_OnAccentColorChanged;
 
             Unloaded?.Invoke(this, new RoutedEventArgs());
 
@@ -283,6 +288,14 @@
                     () => Dispatcher.RunAsync(CoreDispatcherPriority.Low,
                         () => SideBySideDiffViewer.Focus()));
             }
+        }
+
+        private void ThemeSettingsService_OnAccentColorChanged(object sender, Windows.UI.Color color)
+        {
+            Dispatcher.RunAsync(() =>
+            {
+                AccentColorChanged?.Invoke(this, color);
+            });
         }
 
         public string GetText()

--- a/src/Notepads/Controls/TextEditor/TextEditorCore.cs
+++ b/src/Notepads/Controls/TextEditor/TextEditorCore.cs
@@ -149,31 +149,46 @@
             _contentLinesCache = null;
         }
 
-        private void EditorSettingsService_OnFontFamilyChanged(object sender, string fontFamily)
+        private async void EditorSettingsService_OnFontFamilyChanged(object sender, string fontFamily)
         {
-            FontFamily = new FontFamily(fontFamily);
-            SetDefaultTabStopAndLineSpacing(FontFamily, FontSize);
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                FontFamily = new FontFamily(fontFamily);
+                SetDefaultTabStopAndLineSpacing(FontFamily, FontSize);
+            });
         }
 
-        private void EditorSettingsService_OnFontSizeChanged(object sender, int fontSize)
+        private async void EditorSettingsService_OnFontSizeChanged(object sender, int fontSize)
         {
-            FontSize = fontSize;
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                FontSize = fontSize;
+            });
         }
 
-        private void EditorSettingsService_OnDefaultTextWrappingChanged(object sender, TextWrapping textWrapping)
+        private async void EditorSettingsService_OnDefaultTextWrappingChanged(object sender, TextWrapping textWrapping)
         {
-            TextWrapping = textWrapping;
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                TextWrapping = textWrapping;
+            });
         }
 
-        private void EditorSettingsService_OnHighlightMisspelledWordsChanged(object sender, bool isSpellCheckEnabled)
+        private async void EditorSettingsService_OnHighlightMisspelledWordsChanged(object sender, bool isSpellCheckEnabled)
         {
-            IsSpellCheckEnabled = isSpellCheckEnabled;
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                IsSpellCheckEnabled = isSpellCheckEnabled;
+            });
         }
 
-        private void ThemeSettingsService_OnAccentColorChanged(object sender, Windows.UI.Color color)
+        private async void ThemeSettingsService_OnAccentColorChanged(object sender, Windows.UI.Color color)
         {
-            SelectionHighlightColor = Application.Current.Resources["SystemControlForegroundAccentBrush"] as SolidColorBrush;
-            SelectionHighlightColorWhenNotFocused = Application.Current.Resources["SystemControlForegroundAccentBrush"] as SolidColorBrush;
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                SelectionHighlightColor = Application.Current.Resources["SystemControlForegroundAccentBrush"] as SolidColorBrush;
+                SelectionHighlightColorWhenNotFocused = Application.Current.Resources["SystemControlForegroundAccentBrush"] as SolidColorBrush;
+            });
         }
 
         private KeyboardCommandHandler GetKeyboardCommandHandler()

--- a/src/Notepads/Core/NotepadsCore.cs
+++ b/src/Notepads/Core/NotepadsCore.cs
@@ -86,7 +86,6 @@
             Sets.DragItemsCompleted += Sets_DragItemsCompleted;
 
             _extensionProvider = extensionProvider;
-            ThemeSettingsService.OnAccentColorChanged += OnAppAccentColorChanged;
         }
 
         public void OpenNewTextEditor(string fileNamePlaceholder)
@@ -134,6 +133,8 @@
                     Sets.ScrollToLastSet();
                 }
             }
+
+            textEditor.AccentColorChanged += TextEditor_AccentColorChanged;
         }
 
         public void OpenTextEditors(ITextEditor[] editors, Guid? selectedEditorId = null)
@@ -543,7 +544,7 @@
             TextEditorLineEndingChanged?.Invoke(this, textEditor);
         }
 
-        private void OnAppAccentColorChanged(object sender, Color color)
+        private void TextEditor_AccentColorChanged(object sender, Color e)
         {
             if (Sets.Items == null) return;
             foreach (SetsViewItem item in Sets.Items)

--- a/src/Notepads/Extensions/DiffViewer/SideBySideDiffViewer.xaml.cs
+++ b/src/Notepads/Extensions/DiffViewer/SideBySideDiffViewer.xaml.cs
@@ -65,10 +65,13 @@
             Focus();
         }
 
-        private void ThemeSettingsService_OnAccentColorChanged(object sender, Color color)
+        private async void ThemeSettingsService_OnAccentColorChanged(object sender, Color color)
         {
-            LeftBox.SelectionHighlightColor = Application.Current.Resources["SystemControlForegroundAccentBrush"] as SolidColorBrush;
-            RightBox.SelectionHighlightColor = Application.Current.Resources["SystemControlForegroundAccentBrush"] as SolidColorBrush;
+            await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                LeftBox.SelectionHighlightColor = Application.Current.Resources["SystemControlForegroundAccentBrush"] as SolidColorBrush;
+                RightBox.SelectionHighlightColor = Application.Current.Resources["SystemControlForegroundAccentBrush"] as SolidColorBrush;
+            });
         }
 
         private KeyboardCommandHandler GetKeyboardCommandHandler()

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -561,7 +561,7 @@
       <Version>3.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Gaming.XboxGameBar">
-      <Version>4.1.200310001-prerelease</Version>
+      <Version>4.1.200311001-prerelease</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>

--- a/src/Notepads/NotepadsMainPage.xaml.cs
+++ b/src/Notepads/NotepadsMainPage.xaml.cs
@@ -128,25 +128,31 @@
 
             // Setup status bar
             ShowHideStatusBar(EditorSettingsService.ShowStatusBar);
-            EditorSettingsService.OnStatusBarVisibilityChanged += (sender, visibility) =>
+            EditorSettingsService.OnStatusBarVisibilityChanged += async (sender, visibility) =>
             {
-                if (ApplicationView.GetForCurrentView().ViewMode != ApplicationViewMode.CompactOverlay) ShowHideStatusBar(visibility);
+                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, ()=>
+                {
+                    if (ApplicationView.GetForCurrentView().ViewMode != ApplicationViewMode.CompactOverlay) ShowHideStatusBar(visibility);
+                });
             };
 
             // Session backup and restore toggle
             EditorSettingsService.OnSessionBackupAndRestoreOptionChanged += async (sender, isSessionBackupAndRestoreEnabled) =>
             {
-                if (isSessionBackupAndRestoreEnabled)
+                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, async () =>
                 {
-                    SessionManager.IsBackupEnabled = true;
-                    SessionManager.StartSessionBackup(startImmediately: true);
-                }
-                else
-                {
-                    SessionManager.IsBackupEnabled = false;
-                    SessionManager.StopSessionBackup();
-                    await SessionManager.ClearSessionDataAsync();
-                }
+                    if (isSessionBackupAndRestoreEnabled)
+                    {
+                        SessionManager.IsBackupEnabled = true;
+                        SessionManager.StartSessionBackup(startImmediately: true);
+                    }
+                    else
+                    {
+                        SessionManager.IsBackupEnabled = false;
+                        SessionManager.StopSessionBackup();
+                        await SessionManager.ClearSessionDataAsync();
+                    }
+                });
             };
 
             // Sharing

--- a/src/Notepads/NotepadsMainPage.xaml.cs
+++ b/src/Notepads/NotepadsMainPage.xaml.cs
@@ -120,8 +120,10 @@
             NotificationCenter.Instance.SetNotificationDelegate(this);
 
             // Setup theme
-            ThemeSettingsService.AppBackground = RootGrid;
-            ThemeSettingsService.SetRequestedTheme();
+            ThemeSettingsService.OnBackgroundChanged += ThemeSettingsService_OnBackgroundChanged;
+            ThemeSettingsService.OnRequestThemeUpdate += ThemeSettingsService_OnRequestThemeUpdate;
+            ThemeSettingsService.OnRequestAccentColorUpdate += ThemeSettingsService_OnRequestAccentColorUpdate;
+            ThemeSettingsService.SetRequestedTheme(RootGrid, Window.Current.Content, ApplicationView.GetForCurrentView().TitleBar);
 
             // Setup custom Title Bar
             Window.Current.SetTitleBar(AppTitleBar);
@@ -178,6 +180,30 @@
             {
                 PrintArgs.RegisterForPrinting(this);
             }
+        }
+
+        private async void ThemeSettingsService_OnRequestAccentColorUpdate(object sender, EventArgs e)
+        {
+            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                ThemeSettingsService.SetRequestedAccentColor();
+            });
+        }
+
+        private async void ThemeSettingsService_OnRequestThemeUpdate(object sender, EventArgs e)
+        {
+            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                ThemeSettingsService.SetRequestedTheme(RootGrid, Window.Current.Content, ApplicationView.GetForCurrentView().TitleBar);
+            });
+        }
+
+        private async void ThemeSettingsService_OnBackgroundChanged(object sender, Brush backgroundBrush)
+        {
+            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                RootGrid.Background = backgroundBrush;
+            });
         }
 
         private void InitControls()

--- a/src/Notepads/Services/ActivationService.cs
+++ b/src/Notepads/Services/ActivationService.cs
@@ -50,6 +50,7 @@
                 if (xboxGameBarWidgetActivatedEventArgs.IsLaunchActivation)
                 {
                     App.IsFirstInstance = true;
+                    App.IsGameBarWidget = true;
 
                     var xboxGameBarWidget = new XboxGameBarWidget(
                         xboxGameBarWidgetActivatedEventArgs,


### PR DESCRIPTION
Previous change moved the settings panel to a new widget, this means it is now running on a separate UI thread. Because of this many of the places where it attempt to update settings are broken because they assume main notepads page is running on the same page. 

This change resolves these issues by delegating to the proper UI thread where possible. In some cases decoupling was required (especially in ThemeSettingsService where it has a lot of knowledge of the app).