### PR TITLE
Make the Save file operation work as a Game Bar widget

### DIFF
--- a/src/Notepads/Extensions/DispatcherTaskExtensions.cs
+++ b/src/Notepads/Extensions/DispatcherTaskExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI.Core;
+public static class DispatcherTaskExtensions
+{
+    public static async Task<T> RunTaskAsync<T>(this CoreDispatcher dispatcher,
+        Func<Task<T>> func, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal)
+    {
+        var taskCompletionSource = new TaskCompletionSource<T>();
+        await dispatcher.RunAsync(priority, async () =>
+        {
+            try
+            {
+                taskCompletionSource.SetResult(await func());
+            }
+            catch (Exception ex)
+            {
+                taskCompletionSource.SetException(ex);
+            }
+        });
+        return await taskCompletionSource.Task;
+    }
+
+    // There is no TaskCompletionSource<void> so we use a bool that we throw away.
+    public static async Task RunTaskAsync(this CoreDispatcher dispatcher,
+        Func<Task> func, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal) =>
+        await RunTaskAsync(dispatcher, async () => { await func(); return false; }, priority);
+}

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -606,7 +606,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Gaming.XboxGameBar">
-      <Version>5.1.200401003</Version>
+      <Version>5.1.200403001</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>

--- a/src/Notepads/Notepads.csproj
+++ b/src/Notepads/Notepads.csproj
@@ -183,6 +183,7 @@
       <DependentUpon>SideBySideDiffViewer.xaml</DependentUpon>
     </Compile>
     <Compile Include="Extensions\DiffViewer\ISideBySideDiffViewer.cs" />
+    <Compile Include="Extensions\DispatcherTaskExtensions.cs" />
     <Compile Include="Extensions\IContentExtension.cs" />
     <Compile Include="Extensions\DiffViewer\ScrollViewerSynchronizer.cs" />
     <Compile Include="Extensions\DiffViewer\RichTextBlockDiffRenderer.cs" />
@@ -606,7 +607,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Gaming.XboxGameBar">
-      <Version>5.1.200403001</Version>
+      <Version>5.2.200415002</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>

--- a/src/Notepads/NotepadsMainPage.xaml.cs
+++ b/src/Notepads/NotepadsMainPage.xaml.cs
@@ -216,8 +216,8 @@
             MenuCreateNewButton.Click += (sender, args) => NotepadsCore.OpenNewTextEditor(_defaultNewFileName);
             MenuCreateNewWindowButton.Click += async (sender, args) => await OpenNewAppInstance();
             MenuOpenFileButton.Click += async (sender, args) => await OpenNewFiles();
-            MenuSaveButton.Click += async (sender, args) => await Save(NotepadsCore.GetSelectedTextEditor(), saveAs: false);
-            MenuSaveAsButton.Click += async (sender, args) => await Save(NotepadsCore.GetSelectedTextEditor(), saveAs: true);
+            MenuSaveButton.Click += async (sender, args) => await Save(NotepadsCore.GetSelectedTextEditor(), saveAs: false, widget:_widget);
+            MenuSaveAsButton.Click += async (sender, args) => await Save(NotepadsCore.GetSelectedTextEditor(), saveAs: true, widget:_widget);
             MenuSaveAllButton.Click += async (sender, args) =>
             {
                 var success = false;

--- a/src/Notepads/Package.appxmanifest
+++ b/src/Notepads/Package.appxmanifest
@@ -622,9 +622,12 @@
         <Path>Microsoft.Gaming.XboxGameBar.winmd</Path>
           <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetAuthHost" InterfaceId="DC263529-B12F-469E-BB35-B94069F5B15A" />
           <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetControlHost" InterfaceId="C309CAC7-8435-4082-8F37-784523747047" />
+          <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetForegroundWorkerHost" InterfaceId="DDB52B57-FA83-420C-AFDE-6FA556E18B83" />
+          <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetForegroundWorkerPrivate" InterfaceId="42BACDFC-BB28-4E71-99B4-24C034C7B7E0" />
           <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarNavigationKeyCombo" InterfaceId="5EEA3DBF-09BB-42A5-B491-CF561E33C172" />
           <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
           <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
+          <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost2" InterfaceId="28717C8B-D8E8-47A8-AF47-A1D5263BAE9B" />
           <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
       </ProxyStub>
     </Extension>


### PR DESCRIPTION
This change hooks up the Save file operation to show how you can do foreground work when running as a Game Bar widget.